### PR TITLE
Remove unnecessary work on SRS generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ Cargo.lock
 
 # Configuration for Jetbrains
 .idea/
+
+.DS_Store

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.74.1"
 [dependencies]
 ff = { version = "0.13.0", features = ["derive"] }
 digest = "0.10"
-halo2curves = { version = "0.6.0", features = ["bits", "derive_serde"] }
+halo2curves = { git = "https://github.com/ICME-Lab/halo2curves", branch = "main", features = ["bits", "derive_serde"] }
 sha3 = "0.10"
 rayon = "1.7"
 rand_core = { version = "0.6", default-features = false }
@@ -44,9 +44,7 @@ rayon-scan = "0.1.0"
 serde_json = { version = "1.0" }
 
 [target.'cfg(any(target_arch = "x86_64", target_arch = "aarch64"))'.dependencies]
-# grumpkin-msm has been patched to support MSMs for the pasta curve cycle
-# see: https://github.com/lurk-lab/grumpkin-msm/pull/3
-grumpkin-msm = { git = "https://github.com/lurk-lab/grumpkin-msm", branch = "mont_t-abs" }
+grumpkin-msm = { git = "https://github.com/ICME-Lab/grumpkin-msm", branch = "dev" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2.0", default-features = false, features = ["js"] }

--- a/src/provider/kzg_commitment.rs
+++ b/src/provider/kzg_commitment.rs
@@ -161,8 +161,10 @@ where
         fb_msm::multi_scalar_mul::<E::G1>(scalar_bits, window_size, &g_table, &nz_powers_of_beta)
       },
       || {
-        let h_table = fb_msm::get_window_table(scalar_bits, window_size, h);
-        fb_msm::multi_scalar_mul::<E::G2>(scalar_bits, window_size, &h_table, &nz_powers_of_beta)
+        let mut h_vec = vec![E::G2::identity(); max_degree + 1];
+        h_vec[0] = h;
+        h_vec[1] = h * beta;
+        h_vec
       },
     );
 

--- a/src/provider/kzg_commitment.rs
+++ b/src/provider/kzg_commitment.rs
@@ -144,7 +144,7 @@ where
     let g = E::G1::random(&mut rng);
     let h = E::G2::random(rng);
 
-    let nz_powers_of_beta = (0..=max_degree)
+    let nz_powers_of_beta = (0..max_degree)
       .scan(beta, |acc, _| {
         let val = *acc;
         *acc *= beta;
@@ -161,7 +161,7 @@ where
         fb_msm::multi_scalar_mul::<E::G1>(scalar_bits, window_size, &g_table, &nz_powers_of_beta)
       },
       || {
-        let mut h_vec = vec![E::G2::identity(); max_degree + 1];
+        let mut h_vec = vec![E::G2::identity(); max_degree];
         h_vec[0] = h;
         h_vec[1] = h * beta;
         h_vec


### PR DESCRIPTION
In the KZG SRS, we only need $H$ and $\alpha \cdot H$, where $H \in G_2$, and not the whole $\{ H, \alpha \cdot H, ..., \alpha^{d-1} H \}$ as we do for $G \in G_1$.

This is specially relevant for running wasm in the browser, since it is single threaded.

As a side work, I updated the grumpkin and halo2curves library to use ICME forks (otherwise the code didn't compile for me).

Merging into `hypernova-ivc` branch because it seems the one currently being used in `zkEngine`.