### PR TITLE
Remove forced getrandom js feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,9 +46,6 @@ serde_json = { version = "1.0" }
 [target.'cfg(any(target_arch = "x86_64", target_arch = "aarch64"))'.dependencies]
 grumpkin-msm = { git = "https://github.com/ICME-Lab/grumpkin-msm", branch = "dev" }
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-getrandom = { version = "0.2.0", default-features = false, features = ["js"] }
-
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 proptest = "1.2.0"
 pprof = { version = "0.13", optional = true } # in benches under feature "flamegraph"


### PR DESCRIPTION
[getrandom's documentation][doc] says about the `js` Cargo feature:
> Library crates should generally not enable this feature, leaving such a decision to _users_ of their library.

The effect of this feature inclusion is that WebAssembly consumers of the `arecibo` crate are forcibly locked in to using wasm-bindgen rather than supplying their own `getrandom` backend, which can be inconvenient.

This dependency block was introduced in 4b077bcab17f2bfb589775adaa99f6942978b555.

[doc]: https://docs.rs/getrandom/0.2.16/getrandom/index.html#webassembly-support